### PR TITLE
feat: add docs: add minimal DocC catalog

### DIFF
--- a/Sources/Casbin/Casbin.docc/Articles/Adapters.md
+++ b/Sources/Casbin/Casbin.docc/Articles/Adapters.md
@@ -1,0 +1,6 @@
+# Adapters
+
+Adapters load and save policy.
+
+- FileAdapter(filePath: "examples/basic_policy.csv")
+- MemoryAdapter()

--- a/Sources/Casbin/Casbin.docc/Articles/Caching.md
+++ b/Sources/Casbin/Casbin.docc/Articles/Caching.md
@@ -1,0 +1,6 @@
+# Caching
+
+SwiftCasbin includes an optional in-memory cache for enforce results.
+
+- Enable: `e.enableMemoryCache(capacity: 200)`
+- Clear: `e.getCache()?.clear()`

--- a/Sources/Casbin/Casbin.docc/Articles/PolicyManagement.md
+++ b/Sources/Casbin/Casbin.docc/Articles/PolicyManagement.md
@@ -1,0 +1,8 @@
+# Policy Management
+
+Add or remove policy at runtime.
+
+```swift
+_ = try e.addPolicy(params: ["alice", "data1", "read"]).get()
+let removed = try e.removeFilteredPolicy(fieldIndex: 1, fieldValues: ["domain1","data1"]).get()
+```

--- a/Sources/Casbin/Casbin.docc/Articles/QuickStart.md
+++ b/Sources/Casbin/Casbin.docc/Articles/QuickStart.md
@@ -1,0 +1,22 @@
+# Quick Start
+
+Minimal example to authorize a request with SwiftCasbin.
+
+```swift
+import Casbin
+
+let model = try DefaultModel.from(text: ""
+    + "[request_definition]\n"
+    + "r = sub, obj, act\n"
+    + "[policy_definition]\n"
+    + "p = sub, obj, act\n"
+    + "[policy_effect]\n"
+    + "e = some(where (p.eft == allow))\n"
+    + "[matchers]\n"
+    + "m = r.sub == p.sub && r.obj == p.obj && r.act == p.act\n"
+)
+let adapter = MemoryAdapter()
+let e = try Enforcer(m: model, adapter: adapter)
+_ = try e.addPolicy(params: ["alice", "data1", "read"]).get()
+let ok = try e.enforce("alice", "data1", "read").get()
+```

--- a/Sources/Casbin/Casbin.docc/Casbin.md
+++ b/Sources/Casbin/Casbin.docc/Casbin.md
@@ -1,0 +1,36 @@
+# ``Casbin``
+
+SwiftCasbin is a Swift authorization library that evaluates access decisions from a model (CONF) and policy rules (CSV) with RBAC, ABAC, and RESTful matchers.
+
+## Overview
+
+Load a model and policy via an Adapter, then call Enforcer.enforce to authorize a request.
+
+### Quick Start
+
+```swift
+import Casbin
+
+let model = try DefaultModel.from(text: ""
+    + "[request_definition]\n"
+    + "r = sub, obj, act\n"
+    + "[policy_definition]\n"
+    + "p = sub, obj, act\n"
+    + "[policy_effect]\n"
+    + "e = some(where (p.eft == allow))\n"
+    + "[matchers]\n"
+    + "m = r.sub == p.sub && r.obj == p.obj && r.act == p.act\n"
+)
+let adapter = MemoryAdapter()
+let e = try Enforcer(m: model, adapter: adapter)
+_ = try e.addPolicy(params: ["alice", "data1", "read"]).get()
+let ok = try e.enforce("alice", "data1", "read").get()
+```
+
+## Topics
+
+### Guides
+- <doc:QuickStart>
+- <doc:Caching>
+- <doc:Adapters>
+- <doc:PolicyManagement>


### PR DESCRIPTION
Adds a DocC catalog (module landing + short articles). Code is unchanged; this just enables building documentation locally (Xcode > Build Documentation) or via CI later.