### PR TITLE
feat: replace deprecated NIO Lock with NIOLock

### DIFF
--- a/Sources/Casbin/Cache/MemoryCache.swift
+++ b/Sources/Casbin/Cache/MemoryCache.swift
@@ -55,7 +55,7 @@ final class LruCache<Key:Hashable,Value> {
         }
     private var storage:[Key:ListNode] = [:]
     var capacity = 0
-    private var lock:Lock
+    private var lock:NIOLock
     
     /// head's nextNode is the actual first node in the Double Linked-list.
     private var head = ListNode()

--- a/Sources/Casbin/Core/Core.swift
+++ b/Sources/Casbin/Core/Core.swift
@@ -47,7 +47,7 @@ extension Enforcer {
         self.core.storage.locks
     }
 
-    public var sync: Lock {
+    public var sync: NIOLock {
         self.locks.main
     }
     
@@ -86,15 +86,15 @@ extension Enforcer {
     }
     
     public final class Locks {
-        public let main: Lock
-        var storage: [ObjectIdentifier: Lock]
+        public let main: NIOLock
+        var storage: [ObjectIdentifier: NIOLock]
 
         init() {
             self.main = .init()
             self.storage = [:]
         }
 
-        public func lock<Key>(for key: Key.Type) -> Lock
+        public func lock<Key>(for key: Key.Type) -> NIOLock
             where Key: LockKey
         {
             self.main.lock()
@@ -102,7 +102,7 @@ extension Enforcer {
             if let existing = self.storage[ObjectIdentifier(Key.self)] {
                 return existing
             } else {
-                let new = Lock()
+                let new = NIOLock()
                 self.storage[ObjectIdentifier(Key.self)] = new
                 return new
             }


### PR DESCRIPTION
Fix: https://github.com/casbin/SwiftCasbin/issues/28

Small deprecation cleanup to reduce CI warnings on Swift 6 toolchains.\n\nWhat changed\n- Replace NIOConcurrencyHelpers  with the renamed  in:\n  - Sources/Casbin/Core/Core.swift\n  - Sources/Casbin/Cache/MemoryCache.swift\n- No behavioral changes; this is a 1:1 type rename per NIO guidance.\n\nRationale\n- Fixes deprecation warnings seen in CI logs (Swift 6).\n- Keeps the code compatible without changing synchronization strategy.\n\nTesting\n- Test Suite 'All tests' started at 2025-10-10 17:38:40.638.
Test Suite 'CasbinPackageTests.xctest' started at 2025-10-10 17:38:40.638.
Test Suite 'ConfigTests' started at 2025-10-10 17:38:40.638.
Test Case '-[CasbinTests.ConfigTests testFromText]' started.
Test Case '-[CasbinTests.ConfigTests testFromText]' passed (0.001 seconds).
Test Case '-[CasbinTests.ConfigTests testGet]' started.
Test Case '-[CasbinTests.ConfigTests testGet]' passed (0.001 seconds).
Test Suite 'ConfigTests' passed at 2025-10-10 17:38:40.640.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'DefaultModelTests' started at 2025-10-10 17:38:40.640.
Test Case '-[CasbinTests.DefaultModelTests testAbac]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,read,Cached -> false,Response -> true
Test Case '-[CasbinTests.DefaultModelTests testAbac]' passed (0.002 seconds).
Test Case '-[CasbinTests.DefaultModelTests testBasicModel]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, data2, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> false
Test Case '-[CasbinTests.DefaultModelTests testBasicModel]' passed (0.001 seconds).
Test Case '-[CasbinTests.DefaultModelTests testBasicModelNoPolicy]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> false
Test Case '-[CasbinTests.DefaultModelTests testBasicModelNoPolicy]' passed (0.001 seconds).
Test Case '-[CasbinTests.DefaultModelTests testBasicModelWithoutResources]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, write
Test Case '-[CasbinTests.DefaultModelTests testBasicModelWithoutResources]' passed (0.001 seconds).
Test Case '-[CasbinTests.DefaultModelTests testBasicModelWithoutUsers]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data2, write
Test Case '-[CasbinTests.DefaultModelTests testBasicModelWithoutUsers]' passed (0.001 seconds).
Test Case '-[CasbinTests.DefaultModelTests testBasicModelWithRoot]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, data2, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> root,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> root,data1,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> root,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> root,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> false
Test Case '-[CasbinTests.DefaultModelTests testBasicModelWithRoot]' passed (0.001 seconds).
Test Case '-[CasbinTests.DefaultModelTests testBasicModelWithRootNoPolicy]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> root,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> root,data1,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> root,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> root,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> false
Test Case '-[CasbinTests.DefaultModelTests testBasicModelWithRootNoPolicy]' passed (0.001 seconds).
Test Case '-[CasbinTests.DefaultModelTests testRbacModel]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data2_admin, data2, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data2_admin, data2, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, data2, write
Test Case '-[CasbinTests.DefaultModelTests testRbacModel]' passed (0.001 seconds).
Test Case '-[CasbinTests.DefaultModelTests testRbacModelUsinginOp]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
Test Case '-[CasbinTests.DefaultModelTests testRbacModelUsinginOp]' passed (0.001 seconds).
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithCustomData]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:g::g,Data:bob,data2_admin,custom_data
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data2_admin, data2, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data2_admin, data2, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data2_admin, data2, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, data2, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: RemovePolicy, Assertion:g::g,Data:bob,data2_admin,custom_data
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data2_admin, data2, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data2_admin, data2, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, data2, write
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithCustomData]' passed (0.002 seconds).
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithDeny]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read, allow
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data2_admin, data2, read, allow
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data2_admin, data2, write, allow,alice, data2, write, deny
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, data2, write, allow
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithDeny]' passed (0.002 seconds).
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithDomains]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain1, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain1, data1, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain2, data2, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain2, data2, write
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithDomains]' passed (0.002 seconds).
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithDomainsAtRuntimeMockAdapter]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:admin,domain3,data1,read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:g::g,Data:alice,admin,domain3
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain3,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain3, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain1, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: RemoveFilteredPolicy, Assertion:p::p,Removed:2
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain2, data2, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: RemovePolicy, Assertion:p::p,Data:admin,domain2,data2,read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,read,Cached -> false,Response -> false
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithDomainsAtRuntimeMockAdapter]' passed (0.001 seconds).
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithDomainsRuntime]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:admin,domain1,data1,read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:admin,domain1,data1,write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:admin,domain2,data2,read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:admin,domain2,data2,write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:g::g,Data:alice,admin,domain1
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:g::g,Data:bob,admin,domain2
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain1, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain1, data1, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain2, data2, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain2, data2, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: RemoveFilteredPolicy, Assertion:p::p,Removed:2
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain2, data2, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain2, data2, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: RemovePolicy, Assertion:p::p,Data:admin,domain2,data2,read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,write,Cached -> false,Response -> true
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithDomainsRuntime]' passed (0.003 seconds).
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithNotDeny]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data2, write, deny
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithNotDeny]' passed (0.001 seconds).
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithResourceRoles]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data_group_admin, data_group, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data_group_admin, data_group, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, data2, write
Test Case '-[CasbinTests.DefaultModelTests testRbacModelWithResourceRoles]' passed (0.001 seconds).
Test Suite 'DefaultModelTests' passed at 2025-10-10 17:38:40.661.
	 Executed 16 tests, with 0 failures (0 unexpected) in 0.021 (0.021) seconds
Test Suite 'EnforcerTests' started at 2025-10-10 17:38:40.661.
Test Case '-[CasbinTests.EnforcerTests testEnableAutoSave]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: RemovePolicy, Assertion:p::p,Data:alice,data1,read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, data2, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: RemovePolicy, Assertion:p::p,Data:alice,data1,read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, data2, write
Test Case '-[CasbinTests.EnforcerTests testEnableAutoSave]' passed (0.002 seconds).
Test Case '-[CasbinTests.EnforcerTests testFilteredFileAdater]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain1, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain1, data1, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,write,Cached -> false,Response -> false
Test Case '-[CasbinTests.EnforcerTests testFilteredFileAdater]' passed (0.001 seconds).
Test Case '-[CasbinTests.EnforcerTests testGetAndSetAdapterInmem]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, write
Test Case '-[CasbinTests.EnforcerTests testGetAndSetAdapterInmem]' passed (0.001 seconds).
Test Case '-[CasbinTests.EnforcerTests testGetAndSetModel]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> root,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> root,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
Test Case '-[CasbinTests.EnforcerTests testGetAndSetModel]' passed (0.001 seconds).
Test Case '-[CasbinTests.EnforcerTests testIpMatchModel]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 192.168.2.123,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> 192.168.2.0/24, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 10.0.0.5,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> 10.0.0.0/16, data2, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 192.168.2.123,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 192.168.2.123,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 192.168.2.123,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 192.168.0.123,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 192.168.0.123,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 192.168.0.123,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 192.168.0.123,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 10.0.0.5,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 10.0.0.5,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 10.0.0.5,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 192.168.0.1,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 192.168.0.1,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 192.168.0.1,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> 192.168.0.1,data2,write,Cached -> false,Response -> false
Test Case '-[CasbinTests.EnforcerTests testIpMatchModel]' passed (0.002 seconds).
Test Case '-[CasbinTests.EnforcerTests testKeymatchCustomModel]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,/alice_data/123,GET,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, /alice_data/*, GET
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,/alice_data/resource1,POST,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, /alice_data/resource1, POST
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,/alice_data/resource2,GET,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, /alice_data/resource2, GET
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,/bob_data/resource1,POST,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, /bob_data/*, POST
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> cathy,/cathy_data,GET,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> cathy, /cathy_data, (GET)|(POST)
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> cathy,/cathy_data,POST,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> cathy, /cathy_data, (GET)|(POST)
Test Case '-[CasbinTests.EnforcerTests testKeymatchCustomModel]' passed (0.001 seconds).
Test Case '-[CasbinTests.EnforcerTests testKeyMatchModelInMemory]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,/alice_data/resource1,GET,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, /alice_data/*, GET
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,/alice_data/resource1,POST,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, /alice_data/resource1, POST
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,/alice_data/resource2,GET,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, /alice_data/*, GET
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,/alice_data/resource2,POST,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,/bob_data/resource1,GET,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,/bob_data/resource1,POST,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,/bob_data/resource2,POST,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,/bob_data/resource2,GET,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,/alice_data/resource1,GET,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,/alice_data/resource1,POST,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,/alice_data/resource2,GET,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, /alice_data/resource2, GET
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,/alice_data/resource1,POST,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,/bob_data/resource1,GET,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,/bob_data/resource1,POST,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, /bob_data/*, POST
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,/bob_data/resource2,POST,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, /bob_data/*, POST
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,/bob_data/resource2,GET,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> cathy,/cathy_data,GET,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> cathy, /cathy_data, (GET)|(POST)
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> cathy,/cathy_data,POST,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> cathy, /cathy_data, (GET)|(POST)
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> cathy,/cathy_data,DELETE,Cached -> false,Response -> false
Test Case '-[CasbinTests.EnforcerTests testKeyMatchModelInMemory]' passed (0.003 seconds).
Test Case '-[CasbinTests.EnforcerTests testKeyMatchModelInMemoryDeny]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,/alice_data/resource2,POST,Cached -> false,Response -> true
Test Case '-[CasbinTests.EnforcerTests testKeyMatchModelInMemoryDeny]' passed (0.000 seconds).
Test Case '-[CasbinTests.EnforcerTests testNotUsedRbacModelInmemory]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:alice,data1,read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:bob,data2,write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, data2, write
Test Case '-[CasbinTests.EnforcerTests testNotUsedRbacModelInmemory]' passed (0.001 seconds).
Test Case '-[CasbinTests.EnforcerTests testPolicyAbac1]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:r.sub.age > 18,/data1,read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> /data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> /data1,read,Cached -> false,Response -> true
Test Case '-[CasbinTests.EnforcerTests testPolicyAbac1]' passed (0.000 seconds).
Test Case '-[CasbinTests.EnforcerTests testPolicyAbac2]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:admin,post,write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:r.sub == r.obj.author,post,write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:g::g,Data:alice,admin
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, post, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, post, write
Test Case '-[CasbinTests.EnforcerTests testPolicyAbac2]' passed (0.000 seconds).
Test Case '-[CasbinTests.EnforcerTests testRbacModelInMemory]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:alice,data1,read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:bob,data2,write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:data2_admin,data2,read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:data2_admin,data2,write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:g::g,Data:alice,data2_admin
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> alice, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data2_admin, data2, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> data2_admin, data2, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data1,write,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,read,Cached -> false,Response -> false
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> bob, data2, write
Test Case '-[CasbinTests.EnforcerTests testRbacModelInMemory]' passed (0.001 seconds).
Test Case '-[CasbinTests.EnforcerTests testRbacModelInMemoryIndeterminate]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:p::p,Data:alice,data1,invalid
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,data1,read,Cached -> false,Response -> false
Test Case '-[CasbinTests.EnforcerTests testRbacModelInMemoryIndeterminate]' passed (0.000 seconds).
Test Case '-[CasbinTests.EnforcerTests testRoleLinks]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> user501,data9,read,Cached -> false,Response -> false
Test Case '-[CasbinTests.EnforcerTests testRoleLinks]' passed (0.000 seconds).
Test Case '-[CasbinTests.EnforcerTests testSetRoleManager]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain1, data1, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> alice,domain1,data1,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain1, data1, write
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,read,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain2, data2, read
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Enforce Request:Request -> bob,domain2,data2,write,Cached -> false,Response -> true
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Hitted Policies: Explain -> admin, domain2, data2, write
Test Case '-[CasbinTests.EnforcerTests testSetRoleManager]' passed (0.001 seconds).
Test Suite 'EnforcerTests' passed at 2025-10-10 17:38:40.678.
	 Executed 15 tests, with 0 failures (0 unexpected) in 0.016 (0.016) seconds
Test Suite 'KeyMatchTests' started at 2025-10-10 17:38:40.678.
Test Case '-[CasbinTests.KeyMatchTests testglobMatch]' started.
Test Case '-[CasbinTests.KeyMatchTests testglobMatch]' passed (0.000 seconds).
Test Case '-[CasbinTests.KeyMatchTests testIpMatch]' started.
Test Case '-[CasbinTests.KeyMatchTests testIpMatch]' passed (0.000 seconds).
Test Case '-[CasbinTests.KeyMatchTests testKeyMatch]' started.
Test Case '-[CasbinTests.KeyMatchTests testKeyMatch]' passed (0.000 seconds).
Test Case '-[CasbinTests.KeyMatchTests testKeyMatch2]' started.
Test Case '-[CasbinTests.KeyMatchTests testKeyMatch2]' passed (0.000 seconds).
Test Case '-[CasbinTests.KeyMatchTests testKeyMatch3]' started.
Test Case '-[CasbinTests.KeyMatchTests testKeyMatch3]' passed (0.000 seconds).
Test Case '-[CasbinTests.KeyMatchTests testRegexMatch]' started.
Test Case '-[CasbinTests.KeyMatchTests testRegexMatch]' passed (0.000 seconds).
Test Suite 'KeyMatchTests' passed at 2025-10-10 17:38:40.678.
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'RbacApiTests' started at 2025-10-10 17:38:40.678.
Test Case '-[CasbinTests.RbacApiTests testCoreApi_for_RoleApi_with_domain]' started.
Test Case '-[CasbinTests.RbacApiTests testCoreApi_for_RoleApi_with_domain]' passed (0.000 seconds).
Test Case '-[CasbinTests.RbacApiTests testRoleApi]' started.
2025-10-10T17:38:40+0200 info swift.casbin: [Casbin] Policy Management: Event -> Type: AddPolicy, Assertion:g::g,Data:alice,data1_admin
Test Case '-[CasbinTests.RbacApiTests testRoleApi]' passed (0.001 seconds).
Test Suite 'RbacApiTests' passed at 2025-10-10 17:38:40.679.
	 Executed 2 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'UtilsTests' started at 2025-10-10 17:38:40.679.
Test Case '-[CasbinTests.UtilsTests testCsvParse1]' started.
Test Case '-[CasbinTests.UtilsTests testCsvParse1]' passed (0.000 seconds).
Test Case '-[CasbinTests.UtilsTests testCsvParse2]' started.
Test Case '-[CasbinTests.UtilsTests testCsvParse2]' passed (0.000 seconds).
Test Case '-[CasbinTests.UtilsTests testCsvParse3]' started.
Test Case '-[CasbinTests.UtilsTests testCsvParse3]' passed (0.000 seconds).
Test Case '-[CasbinTests.UtilsTests testCsvParse4]' started.
Test Case '-[CasbinTests.UtilsTests testCsvParse4]' passed (0.000 seconds).
Test Case '-[CasbinTests.UtilsTests testCsvParse5]' started.
Test Case '-[CasbinTests.UtilsTests testCsvParse5]' passed (0.000 seconds).
Test Case '-[CasbinTests.UtilsTests testEscapeAssertion]' started.
Test Case '-[CasbinTests.UtilsTests testEscapeAssertion]' passed (0.000 seconds).
Test Suite 'UtilsTests' passed at 2025-10-10 17:38:40.680.
	 Executed 6 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
Test Suite 'CasbinPackageTests.xctest' passed at 2025-10-10 17:38:40.680.
	 Executed 47 tests, with 0 failures (0 unexpected) in 0.041 (0.042) seconds
Test Suite 'All tests' passed at 2025-10-10 17:38:40.680.
	 Executed 47 tests, with 0 failures (0 unexpected) in 0.041 (0.042) seconds
􀟈  Test run started.
􀄵  Testing Library Version: 124.4
􀄵  Target Platform: arm64e-apple-macos14.0
􀟈  Suite "Role Manager Tests" started.
􀟈  Test "Role hierarchy management" started.
􀟈  Test "Clear all roles" started.
􀟈  Test "Domain-specific roles" started.
􀟈  Test "Get users for a role" started.
􁁛  Test "Get users for a role" passed after 0.001 seconds.
􁁛  Test "Clear all roles" passed after 0.001 seconds.
􁁛  Test "Domain-specific roles" passed after 0.001 seconds.
􁁛  Test "Role hierarchy management" passed after 0.001 seconds.
􁁛  Suite "Role Manager Tests" passed after 0.001 seconds.
􁁛  Test run with 4 tests passed after 0.001 seconds. passes locally (macOS 15, Swift 6.1.2).\n\nFollow-ups\n- In a later PR, we can discuss moving to Swift Concurrency or , but this PR intentionally avoids design changes to stay small and focused.