### PR TITLE
docs: add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 SwiftCasbin
 ====
 
+[![CI](https://github.com/casbin/SwiftCasbin/actions/workflows/ci.yml/badge.svg)](https://github.com/casbin/SwiftCasbin/actions/workflows/ci.yml)
 ![Swift 6.0](https://img.shields.io/badge/Swift-6.0-orange)
 ![iOS](https://img.shields.io/badge/iOS-✓-blue)
 ![macOS](https://img.shields.io/badge/macOS-✓-blue)


### PR DESCRIPTION
Adds a CI status badge pointing to the GitHub Actions workflow at .github/workflows/ci.yml.\n\nThis complements the existing platform badges at the top of the README.