### PR TITLE
feat: Small Swift 6 concurrency cleanups to reduce warnings: Sendable hygiene (Filter, handler typealiases)

### DIFF
--- a/Sources/Casbin/Adapter/Adapter.swift
+++ b/Sources/Casbin/Adapter/Adapter.swift
@@ -14,7 +14,7 @@
 
 import NIO
 
-public struct Filter {
+public struct Filter: Sendable {
     public init(p: [String], g: [String]) {
         self.p = p
         self.g = g

--- a/Sources/Casbin/Adapter/FileAdapter.swift
+++ b/Sources/Casbin/Adapter/FileAdapter.swift
@@ -14,8 +14,8 @@
 
 import NIO
 
-public typealias LoadPolicyFileHandler = (String,Model) -> Void
-public typealias LoadFilteredPolicyFileHandler = (String,Model,Filter) -> Bool
+public typealias LoadPolicyFileHandler = @Sendable (String,Model) -> Void
+public typealias LoadFilteredPolicyFileHandler = @Sendable (String,Model,Filter) -> Bool
 
 public final class FileAdapter {
     var filePath:String


### PR DESCRIPTION
Small Swift 6 concurrency cleanups to reduce warnings.