### PR TITLE
refactor(enforcer): remove forced cast warning

### DIFF
--- a/Sources/Casbin/Enforcer.swift
+++ b/Sources/Casbin/Enforcer.swift
@@ -403,8 +403,10 @@ extension Enforcer: CoreApi {
         if autoBuildRoleLinks {
             do {
                 try self.buildRoleLinks().get()
-            } catch  {
-                return .failure(error as! CasbinError)
+            } catch let e as CasbinError {
+                return .failure(e)
+            } catch {
+                return .failure(.OtherErrorMessage(String(describing: error)))
             }
         }
         return registerGFunctions()
@@ -492,5 +494,4 @@ extension Enforcer: CoreApi {
         autoBuildRoleLinks
     }
 }
-
 


### PR DESCRIPTION
Replace a forced cast  with a typed catch and a safe fallback
This removes a compiler warning and avoids a potential crash if a non-CasbinError ever bubbles up, while keeping behavior unchanged on success.

Tests pass locally with Swift 6.1.2.