### PR TITLE
test(swift-testing): migrate RbacApiTests to Swift Testing (phase 4)

### DIFF
--- a/Tests/CasbinTests/RbacApiTests.swift
+++ b/Tests/CasbinTests/RbacApiTests.swift
@@ -4,45 +4,48 @@ import Casbin
 
 @Suite("RBAC API")
 struct RbacApiTests {
-    private func makeEnforcer(_ mfile: String, _ aFile: String? = nil) throws -> Enforcer {
+    private func withEnforcer(_ mfile: String, _ aFile: String? = nil, body: (Enforcer) throws -> Void) throws {
         let pool = NIOThreadPool(numberOfThreads: 1)
         pool.start()
-        defer { try? pool.syncShutdownGracefully() }
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? elg.syncShutdownGracefully() }
+        defer {
+            try? elg.syncShutdownGracefully()
+            try? pool.syncShutdownGracefully()
+        }
         let fileIo = NonBlockingFileIO(threadPool: pool)
-
         let m = try DefaultModel.from(file: TestsfilePath + mfile, fileIo: fileIo, on: elg.next()).wait()
-        let adapter: Adapter = {
-            if let aFile = aFile {
-                return FileAdapter(filePath: TestsfilePath + aFile, fileIo: fileIo, eventloop: elg.next())
-            } else {
-                return MemoryAdapter(on: elg.next())
-            }
-        }()
-        return try Enforcer(m: m, adapter: adapter)
+        let adapter: Adapter
+        if let aFile = aFile {
+            adapter = FileAdapter(filePath: TestsfilePath + aFile, fileIo: fileIo, eventloop: elg.next())
+        } else {
+            adapter = MemoryAdapter(on: elg.next())
+        }
+        let e = try Enforcer(m: m, adapter: adapter)
+        try body(e)
     }
 
     @Test("basic role APIs")
     func roleApi() throws {
-        let e = try makeEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
-        #expect(e.getRoles(for: "alice", domain: nil) == ["data2_admin"])
-        #expect(e.getRoles(for: "bob", domain: nil).isEmpty)
-        #expect(e.getRoles(for: "data2_admin", domain: nil).isEmpty)
-        #expect(e.getRoles(for: "non_exists", domain: nil).isEmpty)
+        try withEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv") { e in
+            #expect(e.getRoles(for: "alice", domain: nil) == ["data2_admin"])
+            #expect(e.getRoles(for: "bob", domain: nil).isEmpty)
+            #expect(e.getRoles(for: "data2_admin", domain: nil).isEmpty)
+            #expect(e.getRoles(for: "non_exists", domain: nil).isEmpty)
 
-        #expect(!e.hasRole(for: "alice", role: "data1_admin", domain: nil))
-        #expect(e.hasRole(for: "alice", role: "data2_admin", domain: nil))
-        _ = try e.addRole(for: "alice", role: "data1_admin", domain: nil).wait()
-        #expect(e.getRoles(for: "alice", domain: nil).sorted() == ["data1_admin", "data2_admin"])
-        #expect(e.getRoles(for: "bob", domain: nil).sorted() == [])
-        #expect(e.getRoles(for: "data2_admin", domain: nil).sorted() == [])
-        #expect(e.getAllActions().sorted() == ["read", "write"])
+            #expect(!e.hasRole(for: "alice", role: "data1_admin", domain: nil))
+            #expect(e.hasRole(for: "alice", role: "data2_admin", domain: nil))
+            _ = try e.addRole(for: "alice", role: "data1_admin", domain: nil).wait()
+            #expect(e.getRoles(for: "alice", domain: nil).sorted() == ["data1_admin", "data2_admin"])
+            #expect(e.getRoles(for: "bob", domain: nil).sorted() == [])
+            #expect(e.getRoles(for: "data2_admin", domain: nil).sorted() == [])
+            #expect(e.getAllActions().sorted() == ["read", "write"])
+        }
     }
 
     @Test("core API with domain")
     func coreApiWithDomain() throws {
-        let e = try makeEnforcer("examples/rbac_with_domains_model.conf", "examples/rbac_with_domains_policy.csv")
-        #expect(e.getAllActions().sorted() == ["read", "write"])
+        try withEnforcer("examples/rbac_with_domains_model.conf", "examples/rbac_with_domains_policy.csv") { e in
+            #expect(e.getAllActions().sorted() == ["read", "write"])
+        }
     }
 }


### PR DESCRIPTION
Converted  from XCTest to Swift Testing.
- Manage per test with  shutdown.
- Keeps  as in prior phases.
- Continue migrating tests in tiny batches to keep reviews easy.