### PR TITLE
feat: fix all remaining Sendable warnings

### DIFF
--- a/Sources/Casbin/Util/Util.swift
+++ b/Sources/Casbin/Util/Util.swift
@@ -81,7 +81,7 @@ public struct Util {
             return res
         }
     }
-    public static func loadPolicyLine(line:String,m:Model) {
+    @Sendable public static func loadPolicyLine(line:String,m:Model) {
         if line.isEmpty || line.starts(with: "#") {
             return
         }
@@ -96,7 +96,7 @@ public struct Util {
             }
         }
     }
-   public static func loadFilteredPolicyLine(line:String,m:Model,f:Filter) -> Bool {
+   @Sendable public static func loadFilteredPolicyLine(line:String,m:Model,f:Filter) -> Bool {
         if line.isEmpty || line.starts(with: "#") {
             return false
         }


### PR DESCRIPTION
## Summary
- Add `@Sendable` attribute to `loadPolicyLine` and `loadFilteredPolicyLine` static functions in Util.swift
- Resolves all remaining Swift 6 concurrency warnings related to passing non-Sendable functions to `@Sendable` handler closures in FileAdapter

## Changes
- `Util.loadPolicyLine(line:m:)` now marked as `@Sendable`
- `Util.loadFilteredPolicyLine(line:m:f:)` now marked as `@Sendable`

## Test plan
- [x] Build completes successfully with no warnings
- [x] No Sendable-related warnings remain in the codebase
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)